### PR TITLE
Update PropertyFactory.php

### DIFF
--- a/src/PropertyFactory.php
+++ b/src/PropertyFactory.php
@@ -124,7 +124,7 @@ class PropertyFactory
                 return FakerMap::words();
 
             case 'bool':
-                return FakerMap::bool();
+                return FakerMap::boolean();
 
             case 'int':
                 return FakerMap::randomDigit();


### PR DESCRIPTION
This PR corrects the FakerMap boolean method name.

`FakerMap::bool()` method doesn't exist as per the current implementation, therefore any bool types resolve to `null` at the moment.

